### PR TITLE
fix: 修复eventBus输出信息不符预期

### DIFF
--- a/Test/event-bus-test.js
+++ b/Test/event-bus-test.js
@@ -7,7 +7,7 @@ const whyCallback1 = (...payload) => {
 }
 
 const whyCallback2 = (...payload) => {
-  console.log("whyCallback1:", payload)
+  console.log("whyCallback2:", payload)
 }
 
 const lileiCallback1 = (...payload) => {

--- a/Test/event-bus-test.js
+++ b/Test/event-bus-test.js
@@ -35,3 +35,12 @@ setTimeout(() => {
   eventBus.emit("why")
   eventBus.emit("lilei")
 }, 3000);
+
+setTimeout(() => {
+  eventBus.clear()
+}, 4000);
+
+setTimeout(() => {
+    eventBus.emit("why")
+    eventBus.emit("lilei")
+}, 5000);

--- a/src/event-bus.js
+++ b/src/event-bus.js
@@ -79,6 +79,9 @@ class HYEventBus {
       delete this.eventBus[eventName]
     }
   }
+  clear() {
+    this.eventBus = {}
+  }
 }
 
 module.exports = HYEventBus


### PR DESCRIPTION
测试函数whyCallback2按理输出'whyCallback2'，这样才区分whyCallback1的输出，到达off移除总线监听效果
![image](https://user-images.githubusercontent.com/38075730/181878323-12ea3872-15a6-41c8-9a26-4821d5710b2c.png)
