### PR TITLE
feat[event-bus]: 新增clear功能，并添加相应测试用例

### DIFF
--- a/Test/event-bus-test.js
+++ b/Test/event-bus-test.js
@@ -35,3 +35,12 @@ setTimeout(() => {
   eventBus.emit("why")
   eventBus.emit("lilei")
 }, 3000);
+
+setTimeout(() => {
+  eventBus.clear()
+}, 4000);
+
+setTimeout(() => {
+    eventBus.emit("why")
+    eventBus.emit("lilei")
+}, 5000);

--- a/src/event-bus.js
+++ b/src/event-bus.js
@@ -79,6 +79,9 @@ class HYEventBus {
       delete this.eventBus[eventName]
     }
   }
+  clear() {
+    this.eventBus = {}
+  }
 }
 
 module.exports = HYEventBus


### PR DESCRIPTION
为event-bus新增clear功能，用于清空所有已监听的事件，相应测试用例通过
clear后打印，仅存事件whyCallback2回调没有被执行进行打印
![image](https://user-images.githubusercontent.com/38075730/181879007-5006fd0c-6f33-4dc4-9611-335505746a22.png)
