### PR TITLE
fix(event-store): add dispatch supports the form of Promise

### DIFF
--- a/src/event-store.js
+++ b/src/event-store.js
@@ -101,7 +101,7 @@ class HYEventStore {
       throw new Error("this action name does not exist, please check it")
     }
     const actionFn = this.actions[actionName]
-    actionFn.apply(this, [this.state, ...args])
+   return actionFn.apply(this, [this.state, ...args])
   }
 }
 


### PR DESCRIPTION
```
 let obj = {
        funcTest: (...args) => {
            return new Promise((resolve, reject) => {
                resolve('event')
            })
        },
      };
      const dispatch = (actionName, ...args) => {
        const actionFn = obj[actionName];
        actionFn.apply(this, [1, 2, 3]);
      };

      dispatch('funcTest').then(res => {
        console.log(res);
      })
```
Uncaught TypeError: Cannot read properties of undefined (reading 'then')
缺少返回值 